### PR TITLE
Ignorerer .git folder og andre hidden ved henting av alle maler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**
 !**/src/test/**
+content/templates/**
 
 ### STS ###
 .apt_generated

--- a/src/main/java/no/nav/familie/dokgen/services/TemplateService.java
+++ b/src/main/java/no/nav/familie/dokgen/services/TemplateService.java
@@ -94,6 +94,7 @@ public class TemplateService {
         try (Stream<Path> paths = Files.list(MalUtil.hentMalRoot(contentRoot))) {
             return paths
                     .filter(Files::isDirectory)
+                    .filter(p -> !p.toFile().isHidden())
                     .map(x -> x.getFileName().toString())
                     .collect(Collectors.toList());
         } catch (IOException e) {


### PR DESCRIPTION
Etter å ha flyttet ut maler til et eget repo, så ble .git en gyldig mal.