### PR TITLE
Endepunkt og servicefunksjon som lager tilpasset dokument basert på request-objekt

### DIFF
--- a/src/main/java/no/nav/dokgen/controller/TemplateController.java
+++ b/src/main/java/no/nav/dokgen/controller/TemplateController.java
@@ -96,7 +96,7 @@ public class TemplateController {
     }
 
     @PostMapping(value = "/template/{templateName}/create-doc", consumes = "application/json")
-    @ApiOperation(value = "Lager dokument, med eller uten header/footer, ut ifra request-objekt", notes = "")
+    @ApiOperation(value = "Lager dokument ut ifra request-objekt", notes = "")
     public ResponseEntity createDocument(@PathVariable String templateName, @RequestBody CreateDocumentRequest documentRequest) {
         Document document = templateService.createDocument(documentRequest, templateName);
         switch (documentRequest.getDocFormat()) {

--- a/src/main/java/no/nav/dokgen/controller/TemplateController.java
+++ b/src/main/java/no/nav/dokgen/controller/TemplateController.java
@@ -2,12 +2,14 @@ package no.nav.dokgen.controller;
 
 
 import io.swagger.annotations.ApiOperation;
+import no.nav.dokgen.controller.api.CreateDocumentRequest;
 import no.nav.dokgen.resources.TemplateResource;
 import no.nav.dokgen.resources.TestDataResource;
 import no.nav.dokgen.services.*;
 import no.nav.dokgen.util.DocFormat;
 import no.nav.dokgen.util.HttpUtil;
 
+import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpStatus;
@@ -85,11 +87,28 @@ public class TemplateController {
         return new ResponseEntity<>(markdown, HttpStatus.OK);
     }
 
+    @Deprecated
     @PostMapping(value = "/template/markdown/to-html", consumes = "text/markdown")
     @ApiOperation(value = "Konverterer markdown til HTML.", notes = "")
     public ResponseEntity createHtmlCustom(@RequestBody String markdownContent) {
         var content = documentGeneratorService.appendHtmlMetadata(markdownContent, DocFormat.HTML);
         return new ResponseEntity<>(content.html(), HttpUtil.genHtmlHeaders(), HttpStatus.OK);
+    }
+
+    @PostMapping(value = "/template/{templateName}/create-doc", consumes = "application/json")
+    @ApiOperation(value = "Lager dokument, med eller uten header/footer, ut ifra request-objekt", notes = "")
+    public ResponseEntity createDocument(@PathVariable String templateName, @RequestBody CreateDocumentRequest documentRequest) {
+        Document document = templateService.createDocument(documentRequest, templateName);
+        switch (documentRequest.getDocFormat()) {
+            case HTML:
+            return new ResponseEntity<>(document.html(), HttpUtil.genHeaders(DocFormat.HTML, templateName, false), HttpStatus.OK);
+
+            case PDF:
+            return new ResponseEntity<>(templateService.generatePdf(document), HttpUtil.genHeaders(DocFormat.PDF, templateName, false), HttpStatus.OK);
+
+            default:
+            throw new RuntimeException("Not yet implemented for CreateDocumentRequest.docFormat = " + documentRequest.getDocFormat().toString());
+        }
     }
 
     @GetMapping(value = "/template/{templateName}/preview-pdf/{testDataName}")
@@ -165,4 +184,5 @@ public class TemplateController {
         byte[] pdf = templateService.createPdf(templateName, payload);
         return new ResponseEntity<>(pdf, HttpUtil.genHeaders(DocFormat.PDF, templateName, true), HttpStatus.OK);
     }
+
 }

--- a/src/main/java/no/nav/dokgen/controller/api/CreateDocumentRequest.java
+++ b/src/main/java/no/nav/dokgen/controller/api/CreateDocumentRequest.java
@@ -1,0 +1,55 @@
+package no.nav.dokgen.controller.api;
+
+import no.nav.dokgen.util.DocFormat;
+
+public class CreateDocumentRequest {
+    DocFormat docFormat;
+    String templateContent;
+
+    boolean isPrecompiled;
+    String mergeFields;
+
+    boolean includeHeader;
+    String headerFields;
+
+    public CreateDocumentRequest() {
+    }
+
+    public CreateDocumentRequest(DocFormat docFormat,
+                                 String templateContent,
+                                 boolean isPrecompiled,
+                                 String mergeFields,
+                                 boolean includeHeader,
+                                 String headerFields) {
+        this.docFormat = docFormat;
+        this.templateContent = templateContent;
+        this.isPrecompiled = isPrecompiled;
+        this.mergeFields = mergeFields;
+        this.includeHeader = includeHeader;
+        this.headerFields = headerFields;
+    }
+
+    public DocFormat getDocFormat() {
+        return docFormat;
+    }
+
+    public String getTemplateContent() {
+        return templateContent;
+    }
+
+    public boolean isPrecompiled() {
+        return isPrecompiled;
+    }
+
+    public String getMergeFields() {
+        return mergeFields;
+    }
+
+    public boolean isIncludeHeader() {
+        return includeHeader;
+    }
+
+    public String getHeaderFields() {
+        return headerFields;
+    }
+}

--- a/src/main/java/no/nav/dokgen/resources/TemplateResource.java
+++ b/src/main/java/no/nav/dokgen/resources/TemplateResource.java
@@ -7,6 +7,8 @@ public class TemplateResource {
 
     public String content;
 
+    public String compiledContent;
+
     public TemplateResource(String name) {
         this.name = name;
     }

--- a/src/main/java/no/nav/dokgen/services/DocumentGeneratorService.java
+++ b/src/main/java/no/nav/dokgen/services/DocumentGeneratorService.java
@@ -53,7 +53,7 @@ public class DocumentGeneratorService {
             body.prepend(headerFunction.apply(header));
             body.append(footer);
         } catch (IOException e) {
-            throw new RuntimeException("Kunne ikke legge til header/footer å dokumentet", e);
+            throw new RuntimeException("Kunne ikke legge til header/footer på dokumentet", e);
         }
     }
 

--- a/src/main/java/no/nav/dokgen/services/DocumentGeneratorService.java
+++ b/src/main/java/no/nav/dokgen/services/DocumentGeneratorService.java
@@ -45,12 +45,12 @@ public class DocumentGeneratorService {
         XRLog.setLoggingEnabled(false);
     }
 
-    public void wrapDocument(Document document, DocFormat format, Function<String, String> withMergeFields) {
+    public void wrapDocument(Document document, DocFormat format, Function<String, String> headerFunction) {
         try {
             String header = Files.readString(FileStructureUtil.getFormatHeader(contentRoot, format), UTF_8);
             String footer = Files.readString(FileStructureUtil.getFormatFooter(contentRoot, format), UTF_8);
             Element body = document.body();
-            body.prepend(withMergeFields.apply(header));
+            body.prepend(headerFunction.apply(header));
             body.append(footer);
         } catch (IOException e) {
             throw new RuntimeException("Kunne ikke legge til header/footer å dokumentet", e);

--- a/src/main/java/no/nav/dokgen/services/JsonService.java
+++ b/src/main/java/no/nav/dokgen/services/JsonService.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -58,10 +59,10 @@ public class JsonService {
         return SchemaLoader.load(rawSchema);
     }
 
-    public void validereJson(Path schemaPath, String json) throws IOException {
+    public void validereJson(Path schemaPath, JsonNode json) throws IOException {
         try {
             Schema schema = getSchema(schemaPath);
-            schema.validate(new JSONObject(json));
+            schema.validate(new JSONObject(Objects.requireNonNull(json, "Ved validering av flettefelt-json").toString()));
         } catch (ValidationException e) {
             Map<String, String> valideringsFeil = e.getCausingExceptions().stream()
                     .collect(Collectors.toMap(ValidationException::getPointerToViolation, ValidationException::getErrorMessage));

--- a/src/main/java/no/nav/dokgen/services/TemplateService.java
+++ b/src/main/java/no/nav/dokgen/services/TemplateService.java
@@ -91,7 +91,7 @@ public class TemplateService {
 
     private String getCompiledTemplate(TemplateResource templateResource, JsonNode mergeFields) throws ValidationException, IOException {
         Template template = compileInLineTemplate(templateResource.getContent());
-        jsonService.validereJson(FileStructureUtil.getTemplateSchemaPath(contentRoot, templateResource.name), mergeFields.toString());
+        jsonService.validereJson(FileStructureUtil.getTemplateSchemaPath(contentRoot, templateResource.name), mergeFields);
         if (template != null) {
             return template.apply(with(mergeFields));
         }
@@ -199,7 +199,7 @@ public class TemplateService {
             }
             return template;
         } catch (IOException e) {
-            throw new RuntimeException("Kunne ikke lage HTML, templateName={} " + templateName, e);
+            throw new RuntimeException("Kunne ikke lage dokument med angitt flettefelt-json", e);
         }
     }
 
@@ -265,8 +265,7 @@ public class TemplateService {
 
     private void validateIfRequired(JsonNode mergeFields, DocFormat format) {
         try {
-            jsonService.validereJson(FileStructureUtil.getFormatSchema(contentRoot, format),
-                    Objects.requireNonNull(mergeFields, "Valideringsfeil: Mangler header-felter").toString());
+            jsonService.validereJson(FileStructureUtil.getFormatSchema(contentRoot, format), mergeFields);
         } catch (FileNotFoundException ignore) {
             // This header does not require validation
         } catch (Exception e) {

--- a/src/main/java/no/nav/dokgen/services/TemplateService.java
+++ b/src/main/java/no/nav/dokgen/services/TemplateService.java
@@ -12,6 +12,7 @@ import com.github.jknack.handlebars.context.MethodValueResolver;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.jknack.handlebars.io.FileTemplateLoader;
+import no.nav.dokgen.controller.api.CreateDocumentRequest;
 import no.nav.dokgen.exceptions.DokgenNotFoundException;
 import no.nav.dokgen.resources.TemplateResource;
 import no.nav.dokgen.util.DocFormat;
@@ -27,14 +28,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static no.nav.dokgen.util.DocFormat.HTML;
+import static no.nav.dokgen.util.DocFormat.PDF;
 
 
 @Service
@@ -163,6 +169,40 @@ public class TemplateService {
         }
     }
 
+    public Document createDocument(CreateDocumentRequest request, String templateName) {
+        try {
+            var template = getCompiledTemplate(request, templateName);
+            JsonNode headerFields = request.getHeaderFields() == null || !request.isIncludeHeader()
+                    ? null
+                    : jsonService.getJsonFromString(request.getHeaderFields());
+            return convertToDocument(request.getDocFormat(), template, request.isIncludeHeader(), headerFields);
+        } catch (IOException e) {
+            throw new RuntimeException("Kunne ikke mappe header-felter til Json", e);
+        }
+    }
+
+    private TemplateResource getCompiledTemplate(CreateDocumentRequest request, String templateName) {
+        try {
+            var template = new TemplateResource(templateName);
+            if (request.getTemplateContent() != null) {
+                // use precompiled or custom template content
+                if (request.isPrecompiled()) {
+                    template.compiledContent = request.getTemplateContent();
+                } else {
+                    JsonNode mergeFields = jsonService.getJsonFromString(request.getMergeFields());
+                    template.compiledContent = compileInlineAndApply(request.getTemplateContent(), with(mergeFields));
+                }
+            } else {
+                // load and compile template from file.
+                JsonNode mergeFields = jsonService.getJsonFromString(request.getMergeFields());
+                template.compiledContent = getCompiledTemplate(getTemplate(templateName), mergeFields);
+            }
+            return template;
+        } catch (IOException e) {
+            throw new RuntimeException("Kunne ikke lage HTML, templateName={} " + templateName, e);
+        }
+    }
+
     public void saveTemplate(String templateName, String payload) {
         try {
             JsonNode jsonContent = jsonService.getJsonFromString(payload);
@@ -190,26 +230,47 @@ public class TemplateService {
         }
     }
 
-    private String convertToHtml(TemplateResource template, JsonNode mergeFields) {
-        Document styledHtml = convertToDocument(template, mergeFields, DocFormat.HTML);
+    private String convertToHtml(TemplateResource template, JsonNode mergeFields) throws IOException {
+        template.compiledContent = getCompiledTemplate(template, mergeFields);
+        Document styledHtml = convertToDocument(HTML, template, false, null);
         return styledHtml.html();
     }
 
-    private byte[] convertToPdf(TemplateResource template, JsonNode mergeFields) {
-        Document styledHtml = convertToDocument(template, mergeFields, DocFormat.PDF);
-        documentGeneratorService.wrapDocument(styledHtml, DocFormat.PDF, header ->
-                compileInlineAndApply(header, with(mergeFields).combine("templateName", template.name)));
+    private byte[] convertToPdf(TemplateResource template, JsonNode mergeFields) throws IOException {
+        template.compiledContent = getCompiledTemplate(template, mergeFields);
+        Document styledHtml = convertToDocument(PDF, template, true, mergeFields);
+        return generatePdf(styledHtml);
+    }
+
+    public byte[] generatePdf(Document document) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        documentGeneratorService.genererPDF(styledHtml, outputStream);
+        documentGeneratorService.genererPDF(document, outputStream);
         return outputStream.toByteArray();
     }
 
-    private Document convertToDocument(TemplateResource template, JsonNode mergeFields, DocFormat format) {
+    private Document convertToDocument(DocFormat format, TemplateResource template, boolean wrapDocument, JsonNode headerFields) {
+        Document styledHtml = documentGeneratorService.appendHtmlMetadata(template.compiledContent, format);
+        if (wrapDocument) {
+            documentGeneratorService.wrapDocument(styledHtml, format, headerFunction(format, template.name, headerFields));
+        }
+        return styledHtml;
+    }
+
+    private Function<String, String> headerFunction(DocFormat format, String templateName, JsonNode mergeFields) {
+        return header -> {
+            validateIfRequired(mergeFields, format);
+            return compileInlineAndApply(header, with(mergeFields).combine("templateName", templateName));
+        };
+    }
+
+    private void validateIfRequired(JsonNode mergeFields, DocFormat format) {
         try {
-            String markdownDocument = getCompiledTemplate(template, mergeFields);
-            return documentGeneratorService.appendHtmlMetadata(markdownDocument, format);
-        } catch (IOException e) {
-            throw new RuntimeException("Ukjent feil ved konvertering av brev", e);
+            jsonService.validereJson(FileStructureUtil.getFormatSchema(contentRoot, format),
+                    Objects.requireNonNull(mergeFields, "Valideringsfeil: Mangler header-felter").toString());
+        } catch (FileNotFoundException ignore) {
+            // This header does not require validation
+        } catch (Exception e) {
+            throw new RuntimeException("Feil ved validering av header-felter", e);
         }
     }
 

--- a/src/main/java/no/nav/dokgen/services/TestDataService.java
+++ b/src/main/java/no/nav/dokgen/services/TestDataService.java
@@ -59,7 +59,7 @@ public class TestDataService {
         JSONObject testDataObject = new JSONObject(testData);
         String testDataContent = testDataObject.toString(2);
         try {
-            jsonService.validereJson(FileStructureUtil.getTemplateSchemaPath(contentRoot, templateName), testDataContent);
+            jsonService.validereJson(FileStructureUtil.getTemplateSchemaPath(contentRoot, templateName), jsonService.getJsonFromString(testData));
             Files.write(FileStructureUtil.getTestDataPath(contentRoot, templateName, testDataName), testDataContent.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
         } catch (IOException e) {
             throw new RuntimeException("Feil ved lagring av testdata for mal=" + templateName, e);

--- a/src/main/java/no/nav/dokgen/util/FileStructureUtil.java
+++ b/src/main/java/no/nav/dokgen/util/FileStructureUtil.java
@@ -1,7 +1,6 @@
 package no.nav.dokgen.util;
 
 import java.nio.file.Path;
-import java.util.Objects;
 
 public class FileStructureUtil {
 
@@ -25,6 +24,10 @@ public class FileStructureUtil {
         return contentRoot.resolve("templates");
     }
 
+    public static Path getFormatSchema(Path contentRoot, DocFormat format) {
+        return contentRoot.resolve("formats/" + format + "schema.json");
+    }
+
     public static Path getFormatHeader(Path contentRoot, DocFormat format) {
         return contentRoot.resolve("formats/" + format + "/header.html");
     }
@@ -41,31 +44,4 @@ public class FileStructureUtil {
         return contentRoot.resolve("fonts/" + fontName);
     }
 
-    public static final class Fold {
-        int start;
-        int end;
-
-        public Fold(int start, int end) {
-            this.start = start;
-            this.end = end;
-        }
-
-        public boolean contains(int lineNr) {
-            return lineNr >= start && lineNr <= end;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Fold fold = (Fold) o;
-            return start == fold.start &&
-                    end == fold.end;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(start, end);
-        }
-    }
 }


### PR DESCRIPTION
Kan f.eks velge å inkludere header/footer uavhengig av dokumentformat,
og legge til schema-validering av header-felter